### PR TITLE
Update intl

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  intl: ^0.15.8
+  intl: ^0.16.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
On new update of flutter (1.10.1), needs intl on version 1.16.0, because of this, was causing conflict with this package.