### PR TITLE
docs: dependency version update!

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ You should ensure that you add the dependency in your flutter project.
 
 ```yaml
 dependencies:
-  bezier_chart: "^1.0.16"
+  bezier_chart: ^1.0.17+1
 ```
 
 You should then run `flutter packages upgrade` or update your packages in IntelliJ.


### PR DESCRIPTION
Thanks for the package!
The dependency version was not updated on the main documentation page 
and that gets updated with the latest one with this PR.
## Before
```yaml
dependencies:
  bezier_chart: "^1.0.16"
```
## Expected
```yaml
dependencies:
  bezier_chart: ^1.0.17+1
```